### PR TITLE
Launch strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ would produce an iTerm window like the one below:
 +---------------------|---------------------+
 ```
 
+### Launch Strategy
+By default *mert* will start a new iTerm window and launch your layout into it. You can choose to launch your layout
+into a new tab, or into the current pane, instead by using the root-level `launch_strategy` option.
+
+See [Tab Launch Strategy](https://github.com/eggplanetio/mert/blob/master/tests/examples/.mertrc-launch-strategy-tab)
+and [In-Place Launch Strategy](https://github.com/eggplanetio/mert/blob/master/tests/examples/.mertrc-launch-strategy-in_place)
+for an example.
 
 ##License
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -76,12 +76,19 @@ function buildLayout(layoutConfig, root, splitStrategy) {
 function launch(config) {
   config = config || {};
   const layout = _.isArray(config.layout) ? config.layout : [ config.layout ];
+  const launchStrategy = config.launch_strategy || 'window';
 
   if (!hasLayout(config)) {
     throw new Error('Your config is missing `layout` property.');
   }
 
-  newWindow();
+  if (launchStrategy === 'tab') {
+    newTab();
+  } else if (launchStrategy === 'window') {
+    newWindow();
+  } else if (launchStrategy !== 'in_place') {
+    throw new Error(`\`${launchStrategy}\` is not a valid launch_strategy. Choose from: [window, tab, in_place]`);
+  }
 
   if (isSimpleLayout(layout)) {
     buildLayout(config.layout, config.root, config.split_strategy);

--- a/tests/examples/.mertrc-launch-strategy-in_place
+++ b/tests/examples/.mertrc-launch-strategy-in_place
@@ -1,0 +1,6 @@
+launch_strategy: in_place
+layout:
+  -
+    - echo "Row 1, Pane 1"
+  -
+    - echo "Row 2, Pane 1"

--- a/tests/examples/.mertrc-launch-strategy-tab
+++ b/tests/examples/.mertrc-launch-strategy-tab
@@ -1,0 +1,6 @@
+launch_strategy: tab
+layout:
+  -
+    - echo "Row 1, Pane 1"
+  -
+    - echo "Row 2, Pane 1"

--- a/tests/test.js
+++ b/tests/test.js
@@ -21,6 +21,8 @@ const examples = [
   'mertrc-base',
   'mertrc-tabs',
   'mertrc-windows-and-tabs',
+  'mertrc-launch-strategy-tab',
+  'mertrc-launch-strategy-in_place',
 ];
 
 examples.forEach((example) => {


### PR DESCRIPTION
This PR implements the additional functionality discussed after [issue #5 was closed](https://github.com/eggplanetio/mert/issues/5#issuecomment-225908086).

`launch_strategy` is a root-level configuration and determines where the layout will be launched.

Valid options are:
- **window**: Starts a new iTerm window and runs the layout. (default)
- **tab**: Opens a new tab in the current window and runs the layout.
- **in_place**: Runs the layout immediately. The current pane will end up
  being the first pane.

Omitting this option results in `window` being used. Specifying an unrecognized `launch_strategy` will result in an error.
