### PR TITLE
Add ability to list globally-defined projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,5 +33,5 @@ if (program.start) {
 if (program.list) {
   const configLoader = require('./lib/config-loader.js');
   const globalConfig = configLoader.loadGlobal();
-  console.log(Object.keys(globalConfig).join('\n'));
+  return console.log(Object.keys(globalConfig).join('\n'));
 }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ program
   .version(package.version)
   .option('init [type]', 'Create new .mertrc file. Options: global or local')
   .option('start [name]', 'Start project by name or by specifying file path (defaults to .mertrc in cwd)')
+  .option('list', 'List projects defined in ~/.mertrc')
   .parse(process.argv);
 
 if (program.init) {
@@ -29,3 +30,8 @@ if (program.start) {
   return launcher.launch(config)
 }
 
+if (program.list) {
+  const configLoader = require('./lib/config-loader.js');
+  const globalConfig = configLoader.loadGlobal();
+  console.log(Object.keys(globalConfig).join('\n'));
+}

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -7,12 +7,7 @@ const clc = require('cli-color');
 function load(name) {
 
   if (name) {
-    let globalMertrc = path.join(os.homedir(), '.mertrc');
-    if (!fs.existsSync(globalMertrc)) throw new Error(
-     clc.red('No ~/.mertrc file found - please create one')
-    );
-
-    const globalConfig = yaml.load(globalMertrc) || {};
+    const globalConfig = loadGlobal();
     let config = globalConfig[name];
 
     if (config) return config;
@@ -38,4 +33,13 @@ function load(name) {
   return localConfig;
 }
 
-module.exports = { load };
+function loadGlobal() {
+  let globalMertrc = path.join(os.homedir(), '.mertrc');
+  if (!fs.existsSync(globalMertrc)) throw new Error(
+   clc.red('No ~/.mertrc file found - please create one')
+  );
+
+  return yaml.load(globalMertrc) || {};
+}
+
+module.exports = { load, loadGlobal };


### PR DESCRIPTION
My `~/.mertrc` is a mishmash of acronyms and weirdly named items. This PR allows a user to recall what's defined in their global `.mertrc` by running `mert list`.
