### PR TITLE
Add support for custom iTerm profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ See [Tab Launch Strategy](https://github.com/eggplanetio/mert/blob/master/tests/
 and [In-Place Launch Strategy](https://github.com/eggplanetio/mert/blob/master/tests/examples/.mertrc-launch-strategy-in_place)
 for an example.
 
+### Profiles
+By default *mert* will use the `Default` iTerm profile. You can use a different profile for your layout
+by adding the root-level `profile` option.
+
+To use a different profile, set the `profile` configuration on the `.mertrc` file:
+
+```yaml
+profile: "MyProfile"
+layout:
+  -
+    - echo "Col 1, Pane 1"
+  -
+    - echo "Col 2, Pane 1"
+    - echo "Col 2, Pane 2"
+```
+
 ## Testing
 
 ```

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -12,14 +12,23 @@ const system = Application('System Events');
 iterm.includeStandardAdditions = true
 iterm.activate();
 
-function newWindow() {
-  iterm.createWindowWithDefaultProfile();
+function newWindow(profile) {
+  if (profile == 'default') {
+    iterm.createWindowWithDefaultProfile();
+  } else {
+    iterm.createWindowWithProfile(profile);
+  }
+
   return iterm.currentWindow().id();
 }
 
-function newTab(windowId) {
+function newTab(windowId, profile) {
   windowId = windowId || iterm.currentWindow().id();
-  iterm.windows.byId(windowId).createTabWithDefaultProfile();
+  if (profile == 'default') {
+    iterm.windows.byId(windowId).createTabWithDefaultProfile();
+  } else {
+    iterm.windows.byId(windowId).createTabWithProfile(profile);
+  }
   return iterm.currentWindow().currentTab().id();
 }
 
@@ -52,9 +61,9 @@ function buildLayout(layoutConfig, root, configShell, splitStrategy, windowId) {
   rows.forEach((row, index) => {
     if ((index) === 0) return;
     if (splitStrategy == 'horizontal') {
-      iterm.windows.byId(windowId).currentTab().sessions.at(index - 1).splitHorizontallyWithDefaultProfile();
+      iterm.windows.byId(windowId).currentTab().sessions.at(index - 1).splitHorizontallyWithSameProfile();
     } else {
-      iterm.windows.byId(windowId).currentTab().sessions.at(index - 1).splitVerticallyWithDefaultProfile();
+      iterm.windows.byId(windowId).currentTab().sessions.at(index - 1).splitVerticallyWithSameProfile();
     }
   });
 
@@ -64,9 +73,9 @@ function buildLayout(layoutConfig, root, configShell, splitStrategy, windowId) {
     row.forEach((cmd, cmdIndex) => {
       if (cmdIndex !== row.length - 1) {
         if (splitStrategy == 'horizontal') {
-          iterm.windows.byId(windowId).currentTab().sessions.at(cmdCounter).splitVerticallyWithDefaultProfile();
+          iterm.windows.byId(windowId).currentTab().sessions.at(cmdCounter).splitVerticallyWithSameProfile();
         } else {
-          iterm.windows.byId(windowId).currentTab().sessions.at(cmdCounter).splitHorizontallyWithDefaultProfile();
+          iterm.windows.byId(windowId).currentTab().sessions.at(cmdCounter).splitHorizontallyWithSameProfile();
         }
       }
       cmd = { text: `cd ${root || process.cwd()} ${continueIfSuccess} ${cmd}` };
@@ -81,6 +90,7 @@ function launch(config) {
   config = config || {};
   const layout = _.isArray(config.layout) ? config.layout : [ config.layout ];
   const launchStrategy = config.launch_strategy || 'window';
+  const profile = config.profile || 'default';
 
   if (!hasLayout(config)) {
     throw new Error('Your config is missing `layout` property.');
@@ -88,9 +98,9 @@ function launch(config) {
 
   var windowId;
   if (launchStrategy === 'tab') {
-    newTab();
+    newTab(null, profile);
   } else if (launchStrategy === 'window') {
-    windowId = newWindow();
+    windowId = newWindow(profile);
   } else if (launchStrategy !== 'in_place') {
     throw new Error(`\`${launchStrategy}\` is not a valid launch_strategy. Choose from: [window, tab, in_place]`);
   }
@@ -103,24 +113,22 @@ function launch(config) {
   layout.forEach((item, layoutIndex) => {
     if (hasTabs(item)) {
       item.tabs.forEach((tab, tabIndex) => {
-        if (tabIndex !== 0) { newTab(windowId); }
+        if (tabIndex !== 0) { newTab(windowId, profile); }
         buildLayout(
           tab.layout,
           tab.root || item.root || config.root,
           config.shell,
           tab.split_strategy || item.split_strategy || config.split_strategy,
-          windowId
+          windowId,
+          profile
         );
       });
     }
     else if (hasLayout(item)) {
-      newWindow();
+      newWindow(profile);
       buildLayout(item.layout, item.root || config.root, config.shell, item.split_strategy || config.split_srategy);
     }
   });
-
-
-
 }
 
 module.exports = { launch }

--- a/tests/examples/.mertrc-profile
+++ b/tests/examples/.mertrc-profile
@@ -1,0 +1,11 @@
+profile: Default
+layout:
+  -
+    - echo "Row 1, Pane 1"
+  -
+    - echo "Row 2, Pane 1"
+    - echo "Row 2, Pane 2"
+  -
+    - echo "Row 3, Pane 1"
+    - echo "Row 3, Pane 2"
+    - echo "Row 3, Pane 3"

--- a/tests/test.js
+++ b/tests/test.js
@@ -23,6 +23,7 @@ const examples = [
   'mertrc-windows-and-tabs',
   'mertrc-launch-strategy-tab',
   'mertrc-launch-strategy-in_place',
+  'mertrc-profile',
 ];
 
 examples.forEach((example) => {


### PR DESCRIPTION
Hi @briangonzalez,

I know this project hasn't been touched in a while, but I still use it every day. Thanks for building and maintaining this project!

I would like to use a separate profile when I launch mert, however that has not been possible. This PR adds the ability to set a `profile` option to the root-level `.mertrc`.

Here's what I added to the README:

### Profiles
By default *mert* will use the `Default` iTerm profile. You can use a different profile for your layout
by adding the root-level `profile` option.

To use a different profile, set the `profile` configuration on the `.mertrc` file:

```yaml
profile: "MyProfile"
layout:
  -
    - echo "Col 1, Pane 1"
  -
    - echo "Col 2, Pane 1"
    - echo "Col 2, Pane 2"
```